### PR TITLE
fix the path of main.go while building the project

### DIFF
--- a/pkg/plugins/libGo/v1alpha/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/libGo/v1alpha/scaffolds/internal/templates/makefile.go
@@ -111,10 +111,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -o bin/manager cmd/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run ./cmd/main.go
 
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .


### PR DESCRIPTION
fix the path of main.go while building the project